### PR TITLE
FEATURE: Allow access to properties that are deeper down the object tree

### DIFF
--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -21,7 +21,7 @@ import {NgTableSorting} from './ng-table-sorting.directive';
       </thead>
       <tbody>
       <tr *ngFor="#row of rows">
-        <td *ngFor="#column of columns">{{row[column.name]}}</td>
+        <td *ngFor="#column of columns">{{getData(row, column.name)}}</td>
       </tr>
       </tbody>
     </table>
@@ -68,5 +68,9 @@ export class NgTable {
   onChangeTable(column:any) {
     this.columns = [column];
     this.tableChanged.emit({sorting: this.configColumns});
+  }
+
+  getData(row:any, propertyName:string) {
+    return propertyName.split('.').reduce((prev, curr) => prev[curr], row);
   }
 }


### PR DESCRIPTION
The current implementation only allows the user to access a row's first-level properties.

For example, if you have some underlying objects that look like this
```
let students = [
  {name: 'ABC', address: {number: 123, street: ABC Street'}, phones: [{type: 'cell', number: 123456789}]},
  {name: 'XYZ', address: {number: 456, street: 'XYZ Street'}, phones: [{type: 'cell', number: 123456789}]}
];
``` 
and you want to display the street on the table, you will first have to map them to something like this
```
let rows = students.map(student => {
  return {name: student.name, addressNumber: student.address.number, addressStreet: student.address.street};
})
```
before you can assign this to `ngTable`'s `rows` input. It's because `rows[0]['address.number']` will return `undefined`.

I propose we allow users to access properties that are deeper than the first-level properties.

For example, to display the street name, one can simply set the `column.name` to `'address.street'`. This notation will work for array too. For example, to show the first phone number, just set `column.name` to `'phones.0.number'`.