### PR TITLE
Bug: allowing columns to be sorted even when they're set to 'false'

### DIFF
--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -66,7 +66,7 @@ export class NgTableComponent {
 
   public onChangeTable(column:any):void {
     this._columns.forEach((col:any) => {
-      if (col.name !== column.name) {
+      if (col.name !== column.name && col.sort !== false) {
         col.sort = '';
       }
     });

--- a/demo/components/table/table-demo.ts
+++ b/demo/components/table/table-demo.ts
@@ -61,7 +61,7 @@ export class TableDemoComponent implements OnInit {
     let sort:string = void 0;
 
     for (let i = 0; i < columns.length; i++) {
-      if (columns[i].sort !== '') {
+      if (columns[i].sort !== '' && columns[i].sort !== false) {
         columnName = columns[i].name;
         sort = columns[i].sort;
       }


### PR DESCRIPTION
In your Demo, the sort for Position is disabled by default. But if you click any column other than Position, and then click Position, the sort: false has been set to sort: ' '.
