### PR TITLE
Relax Angular2 peer dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
   "homepage": "https://github.com/valor-software/ng2-table#readme",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/common": "~2.0.0",
-    "@angular/compiler": "~2.0.0",
-    "@angular/core": "~2.0.0",
-    "@angular/forms": "~2.0.0"
+    "@angular/common": "^2.0.0",
+    "@angular/compiler": "^2.0.0",
+    "@angular/core": "^2.0.0",
+    "@angular/forms": "^2.0.0"
   },
   "devDependencies": {
     "@angular/common": "2.0.1",


### PR DESCRIPTION
  This commit changes Angular2 peer dependancies to use a caret instead of
  tilde.

  This ensures as the Angular2 team releases new minor versions
  rapidly this package will not throw an exception for UNMET PEER
  DEPENDANCY

Other packages by valor-software such as ng2-bootstrap already use the caret for specifying Angular2 Peer Dependencies and this package should be updated to match.

cc: @valorkin @otelnov 
