### PR TITLE
Allow user to specify property 'pipe' on column object to allow for custom formatting pipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ npm-debug.log
 /components/**/*.js
 /components/**/*.js.map
 /components/**/*.d.ts
+/pipes/**/*.js
+/pipes/**/*.js.map
+/pipes/**/*.d.ts
 ng2-table.js
 ng2-table.js.map
 ng2-table.d.ts

--- a/components/ng-table-module.ts
+++ b/components/ng-table-module.ts
@@ -5,10 +5,11 @@ import { NgTableComponent } from './table/ng-table.component';
 import { NgTableFilteringDirective } from './table/ng-table-filtering.directive';
 import { NgTablePagingDirective } from './table/ng-table-paging.directive';
 import { NgTableSortingDirective } from './table/ng-table-sorting.directive';
+import { AnyPipe } from '../pipes/AnyPipe';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [NgTableComponent, NgTableFilteringDirective, NgTablePagingDirective, NgTableSortingDirective],
+  declarations: [NgTableComponent, NgTableFilteringDirective, NgTablePagingDirective, NgTableSortingDirective, AnyPipe],
   exports: [NgTableComponent, NgTableFilteringDirective, NgTablePagingDirective, NgTableSortingDirective]
 })
 export class Ng2TableModule {

--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -27,7 +27,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
         </td>
       </tr>
         <tr *ngFor="let row of rows">
-          <td (click)="cellClick(row, column.name)" *ngFor="let column of columns" [innerHtml]="sanitize(getData(row, column.name))"></td>
+          <td (click)="cellClick(row, column.name)" *ngFor="let column of columns" [innerHtml]="sanitize(getData(row, column.name) | anyPipe:column.pipe)"></td>
         </tr>
       </tbody>
     </table>

--- a/pipes/AnyPipe.ts
+++ b/pipes/AnyPipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform, Injectable } from '@angular/core';
+
+@Pipe({
+  name: 'anyPipe',
+  pure: false
+})
+@Injectable()
+export class AnyPipe implements PipeTransform {
+  public transform(value: any, pipe: PipeTransform):any {
+    if(!pipe) {
+      return value;
+    }
+    return pipe.transform(value);
+  }
+}


### PR DESCRIPTION
What this will allow users to do is create a pipe object in their component and set the pipe property on their column:

``` typescript
columns:Array<any> = [
  {title: 'My Column Title', name: 'columnName', pipe: new MyPipe()}
]
```

For pipes like CurrencyPipe that take parameters, the user can make their own pipe that extends CurrencyPipe and pass the desired parameters. For example:

``` typescript
import { Pipe, PipeTransform, Injectable } from '@angular/core';
import { CurrencyPipe } from '@angular/common';

@Pipe({
  name: 'usd',
  pure: 'false'
})
@Injectable()
export class USDPipe extends CurrencyPipe {
  constructor() {
    super("en-US");
  }

  public transform(money:number):string {
    return super.transform(money, "USD", true);
  }
}
```
