### PR TITLE
add feature to highlight the selected row

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Follow me [![twitter](https://img.shields.io/twitter/follow/valorkin.svg?style=s
   - `filtering` (`?any`) - switch on the filtering plugin
     - `filterString` (`string`) - the default value for filter
     - `columnName` (`string`) - the property name in raw data
-  - `className` (`string|Array<string>`) - additional CSS classes that should be added to a <table>
+  - `className` (`string|Array<string>`) - additional CSS classes that should be added to a `<table>`
+  - `selectedRowClass` (`string`) - CSS class that should be added to the selected row. Clicking on an already selected row removes the class.
 
 - `rows` (`?Array<any>`) - only list of the rows which should be displayed
 - `columns` (`?Array<any>`) - config for columns (+ sorting settings if it's needed)

--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import {isNullOrUndefined} from "util";
 
 @Component({
   selector: 'ng-table',
@@ -26,7 +27,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
                  (tableChanged)="onChangeTable(config)"/>
         </td>
       </tr>
-        <tr *ngFor="let row of rows">
+        <tr *ngFor="let row of rows" [ngClass]="setSelectedRow(row)">
           <td (click)="cellClick(row, column.name)" *ngFor="let column of columns" [innerHtml]="sanitize(getData(row, column.name))"></td>
         </tr>
       </tbody>
@@ -44,6 +45,9 @@ export class NgTableComponent {
     }
     if (conf.className instanceof Array) {
       conf.className = conf.className.join(' ');
+    }
+    if(!conf.selectedRowClass){
+      conf.selectedRowClass = '';
     }
     this._config = conf;
   }
@@ -75,7 +79,7 @@ export class NgTableComponent {
 
   private _columns:Array<any> = [];
   private _config:any = {};
-
+  private _currentSelectedRow: any = null;
   public constructor(private sanitizer:DomSanitizer) {
   }
 
@@ -118,5 +122,17 @@ export class NgTableComponent {
 
   public cellClick(row:any, column:any):void {
     this.cellClicked.emit({row, column});
+    if(this._currentSelectedRow === row){
+      this._currentSelectedRow = null
+    } else {
+      this._currentSelectedRow = row;
+    }
+
+  }
+
+  public setSelectedRow(row:any):any {
+    let classObj:any = {};
+    classObj[this._config.selectedRowClass] = this._currentSelectedRow === row;
+   return classObj;
   }
 }

--- a/components/table/readme.md
+++ b/components/table/readme.md
@@ -27,7 +27,8 @@ There are only simple table with 3 plugins/directives: `filtering`, `paging`, `s
   - `filtering` (`?any`) - switch on the filtering plugin
     - `filterString` (`string`) - the default value for filter
     - `columnName` (`string`) - the property name in raw data
-  - `className` (`string|Array<string>`) - additional CSS classes that should be added to a <table>
+  - `className` (`string|Array<string>`) - additional CSS classes that should be added to a `<table>`
+      - `selectedRowClass` (`string`) - CSS class that should be added to the selected row. Clicking on an already selected row removes the class.
 
 - `rows` (`?Array<any>`) - only list of the rows which should be displayed
 - `columns` (`?Array<any>`) - config for columns (+ sorting settings if it's needed)

--- a/demo/components/table/table-demo.ts
+++ b/demo/components/table/table-demo.ts
@@ -33,7 +33,8 @@ export class TableDemoComponent implements OnInit {
     paging: true,
     sorting: {columns: this.columns},
     filtering: {filterString: ''},
-    className: ['table-striped', 'table-bordered']
+    className: ['table-striped', 'table-bordered'],
+    selectedRowClass : 'selectedRow'
   };
 
   private data:Array<any> = TableData;

--- a/demo/index.html
+++ b/demo/index.html
@@ -29,6 +29,9 @@
     section {
       padding-top: 30px;
     }
+    .selectedRow {
+      background: yellow !important;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
I implemented highlighting of the selected row requested by #342 . This is done by adding the class name to be used for highlighting to the config object of the table. That means you have set the new `selectedRowClass` property of the config to the class that you want to apply to the selected row. 

Example: 
``` typescript  
public config:any = {
    paging: true,
    sorting: {columns: this.columns},
    filtering: {filterString: ''},
    className: ['table-striped', 'table-bordered'],
    selectedRowClass : 'selectedRow'
  };
```
I have updated the readme files and demo app accordingly.

This is not the only option/implementation to provide this functionality but it's simple and sufficient for my use case. If I should should further change or extend the code please let me know. :)

cheers 