### PR TITLE
Added option to create column with action buttons.

### DIFF
--- a/components/ng-table-directives.ts
+++ b/components/ng-table-directives.ts
@@ -2,4 +2,5 @@ import { NgTableComponent } from './table/ng-table.component';
 import { NgTableFilteringDirective } from './table/ng-table-filtering.directive';
 import { NgTablePagingDirective } from './table/ng-table-paging.directive';
 import { NgTableSortingDirective } from './table/ng-table-sorting.directive';
-export const NG_TABLE_DIRECTIVES = [NgTableComponent, NgTableFilteringDirective, NgTablePagingDirective, NgTableSortingDirective];
+import { TooltipDirective } from 'ng2-bootstrap';
+export const NG_TABLE_DIRECTIVES = [NgTableComponent, NgTableFilteringDirective, NgTablePagingDirective, NgTableSortingDirective, TooltipDirective];

--- a/components/ng-table-module.ts
+++ b/components/ng-table-module.ts
@@ -5,11 +5,12 @@ import { NgTableComponent } from './table/ng-table.component';
 import { NgTableFilteringDirective } from './table/ng-table-filtering.directive';
 import { NgTablePagingDirective } from './table/ng-table-paging.directive';
 import { NgTableSortingDirective } from './table/ng-table-sorting.directive';
+import { TooltipModule } from 'ng2-bootstrap';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, TooltipModule],
   declarations: [NgTableComponent, NgTableFilteringDirective, NgTablePagingDirective, NgTableSortingDirective],
-  exports: [NgTableComponent, NgTableFilteringDirective, NgTablePagingDirective, NgTableSortingDirective]
+  exports: [NgTableComponent, NgTableFilteringDirective, NgTablePagingDirective, NgTableSortingDirective, TooltipModule]
 })
 export class Ng2TableModule {
 }

--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -10,7 +10,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
           <th *ngFor="let column of columns" [ngTableSorting]="config" [column]="column" 
               (sortChanged)="onChangeTable($event)" ngClass="{{column.className || ''}}">
             {{column.title}}
-            <i *ngIf="config && column.sort" class="pull-right fa"
+            <i *ngIf="config && config.addIconSort && column.sort" class="pull-right fa"
               [ngClass]="{'fa-chevron-down': column.sort === 'desc', 'fa-chevron-up': column.sort === 'asc'}"></i>
           </th>
           <th *ngIf="enableColumnAction(config.columnActions, actions)">

--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -126,7 +126,7 @@ export class NgTableComponent {
   }
 
   public getData(row: any, propertyName: string): string {
-    return propertyName.split('.').reduce((prev: any, curr: string) => prev[curr], row);
+    return row[propertyName];
   }
 
   public cellClick(row: any, column: any): void {

--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -7,11 +7,11 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
     <table class="table dataTable" ngClass="{{config.className || ''}}" role="grid" style="width: 100%;">
       <thead>
         <tr role="row">
-          <th *ngFor="let column of columns" [ngTableSorting]="config" [column]="column" 
+          <th *ngFor="let column of columns" [ngTableSorting]="config" [column]="column"
               (sortChanged)="onChangeTable($event)" ngClass="{{column.className || ''}}">
             {{column.title}}
             <i *ngIf="config && config.addIconSort && column.sort" class="pull-right fa"
-              [ngClass]="{'fa-chevron-down': column.sort === 'desc', 'fa-chevron-up': column.sort === 'asc'}"></i>
+               [ngClass]="{'fa-chevron-down': column.sort === 'desc', 'fa-chevron-up': column.sort === 'asc'}"></i>
           </th>
           <th *ngIf="enableColumnAction(config.columnActions, actions)">
             {{config.columnActions.title}}
@@ -30,11 +30,12 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
         <td *ngIf="enableColumnAction(config.columnActions, actions)"></td>
       </tr>
         <tr *ngFor="let row of rows">
-          <td (click)="cellClick(row, column.name)" *ngFor="let column of columns" [innerHtml]="sanitize(getData(row, column.name))"></td>
+          <td (click)="cellClick(row, column.name)" *ngFor="let column of columns"
+              [innerHtml]="sanitize(getData(row, column.name))"></td>
           <td *ngIf="enableColumnAction(config.columnActions, actions)">
-            <a *ngFor="let action of actions" 
-                class="" ngClass="{{action.classBtn || ''}}"
-                (click)="clickActions(row, action)">
+            <a *ngFor="let action of actions"
+               class="" ngClass="{{action.classBtn || ''}}"
+               (click)="clickActions(row, action)">
                 <i class="" ngClass="{{action.classIcon || ''}}"></i> {{action.title}}
              </a>
           </td>
@@ -68,6 +69,7 @@ export class NgTableComponent {
 
   @Input()
   public set columns(values: Array<any>) {
+    let newColumns: Array<any> = [];
     values.forEach((value: any) => {
       if (value.filtering) {
         this.showFilterRow = true;
@@ -79,10 +81,9 @@ export class NgTableComponent {
       if (column) {
         Object.assign(column, value);
       }
-      if (!column) {
-        this._columns.push(value);
-      }
+      newColumns.push(value);
     });
+    this._columns = newColumns;
   }
 
   private _columns: Array<any> = [];

--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -1,5 +1,5 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
-import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Component({
   selector: 'ng-table',
@@ -91,10 +91,6 @@ export class NgTableComponent {
   public constructor(private sanitizer: DomSanitizer) {
   }
 
-  private enableColumnAction(addColumnAction: boolean, actions: any): boolean {
-    return addColumnAction && actions;
-  }
-
   public sanitize(html: string): SafeHtml {
     return this.sanitizer.bypassSecurityTrustHtml(html);
   }
@@ -138,5 +134,9 @@ export class NgTableComponent {
 
   public clickActions(row: any, action: any): void {
     this.actionsclicked.emit({row, action});
+  }
+
+  public enableColumnAction(addColumnAction: boolean, actions: any): boolean {
+    return addColumnAction && actions;
   }
 }

--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -33,7 +33,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
           <td (click)="cellClick(row, column.name)" *ngFor="let column of columns"
               [innerHtml]="sanitize(getData(row, column.name))"></td>
           <td *ngIf="enableColumnAction(config.columnActions, actions)">
-            <a *ngFor="let action of actions"
+            <a *ngFor="let action of actions" tooltip="{{action.tooltip || ''}}" placement="top"
                class="" ngClass="{{action.classBtn || ''}}"
                (click)="clickActions(row, action)">
                 <i class="" ngClass="{{action.classIcon || ''}}"></i> {{action.title}}

--- a/demo/components/table/table-data.ts
+++ b/demo/components/table/table-data.ts
@@ -1,3 +1,22 @@
+
+export const TableActions:Array<any> = [
+  {
+    'title': '',
+    'type': 'edit',
+    'tooltip': 'Edit',
+    'classBtn': '',
+    'classIcon': 'fa fa-pencil',
+  },
+  {
+    'title': '',
+    'type': 'delete',
+    'tooltip': 'Delete',
+    'classBtn': '',
+    'classIcon': 'fa fa-trash',
+  }
+];
+
+
 export const TableData:Array<any> = [
   {
     'name': 'Victoria Cantrell',

--- a/demo/components/table/table-data.ts
+++ b/demo/components/table/table-data.ts
@@ -1,23 +1,20 @@
-
-export const TableActions:Array<any> = [
+export const TableActions: Array<any> = [
   {
     'title': '',
     'type': 'edit',
     'tooltip': 'Edit',
     'classBtn': '',
-    'classIcon': 'fa fa-pencil',
-  },
-  {
+    'classIcon': 'fa fa-pencil'
+  }, {
     'title': '',
     'type': 'delete',
     'tooltip': 'Delete',
     'classBtn': '',
-    'classIcon': 'fa fa-trash',
+    'classIcon': 'fa fa-trash'
   }
 ];
 
-
-export const TableData:Array<any> = [
+export const TableData: Array<any> = [
   {
     'name': 'Victoria Cantrell',
     'position': 'Integer Corporation',

--- a/demo/components/table/table-demo.html
+++ b/demo/components/table/table-demo.html
@@ -10,7 +10,8 @@
 <ng-table [config]="config"
           (tableChanged)="onChangeTable(config)"
           (cellClicked)="onCellClick($event)"
-          [rows]="rows" [columns]="columns">
+          (actionsclicked)="onActionClick($event)"
+          [rows]="rows" [columns]="columns" [actions]="actions">
 </ng-table>
 <pagination *ngIf="config.paging"
             class="pagination-sm"

--- a/demo/components/table/table-demo.ts
+++ b/demo/components/table/table-demo.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { TableData } from './table-data';
+import {TableData, TableActions} from './table-data';
 
 // webpack html imports
 let template = require('./table-demo.html');
@@ -9,7 +9,10 @@ let template = require('./table-demo.html');
   template
 })
 export class TableDemoComponent implements OnInit {
+
   public rows:Array<any> = [];
+  public actions:Array<any> = TableActions;
+
   public columns:Array<any> = [
     {title: 'Name', name: 'name', filtering: {filterString: '', placeholder: 'Filter by name'}},
     {
@@ -23,6 +26,7 @@ export class TableDemoComponent implements OnInit {
     {title: 'Start date', className: 'text-warning', name: 'startDate'},
     {title: 'Salary ($)', name: 'salary'}
   ];
+
   public page:number = 1;
   public itemsPerPage:number = 10;
   public maxSize:number = 5;
@@ -31,6 +35,7 @@ export class TableDemoComponent implements OnInit {
 
   public config:any = {
     paging: true,
+    columnActions: {title: 'Actions'},
     sorting: {columns: this.columns},
     filtering: {filterString: ''},
     className: ['table-striped', 'table-bordered']
@@ -106,7 +111,7 @@ export class TableDemoComponent implements OnInit {
     filteredData.forEach((item:any) => {
       let flag = false;
       this.columns.forEach((column:any) => {
-        if (item[column.name].toString().match(this.config.filtering.filterString)) {
+        if (column.name != 'action' && item[column.name].toString().match(this.config.filtering.filterString)) {
           flag = true;
         }
       });
@@ -135,6 +140,10 @@ export class TableDemoComponent implements OnInit {
   }
 
   public onCellClick(data: any): any {
+    console.log(data);
+  }
+
+  public onActionClick(data: any): any {
     console.log(data);
   }
 }

--- a/demo/components/table/table-demo.ts
+++ b/demo/components/table/table-demo.ts
@@ -34,6 +34,7 @@ export class TableDemoComponent implements OnInit {
   public length:number = 0;
 
   public config:any = {
+    addIconSort: true,
     paging: true,
     columnActions: {title: 'Actions'},
     sorting: {columns: this.columns},

--- a/demo/components/table/table-demo.ts
+++ b/demo/components/table/table-demo.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import {TableData, TableActions} from './table-data';
+import { TableData, TableActions } from './table-data';
 
 // webpack html imports
 let template = require('./table-demo.html');
@@ -111,7 +111,7 @@ export class TableDemoComponent implements OnInit {
     filteredData.forEach((item:any) => {
       let flag = false;
       this.columns.forEach((column:any) => {
-        if (column.name != 'action' && item[column.name].toString().match(this.config.filtering.filterString)) {
+        if (column.name !== 'action' && item[column.name].toString().match(this.config.filtering.filterString)) {
           flag = true;
         }
       });

--- a/demo/demo.module.ts
+++ b/demo/demo.module.ts
@@ -3,8 +3,9 @@ import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 
-import { PaginationModule } from 'ng2-bootstrap/ng2-bootstrap';
-import { TabsModule } from 'ng2-bootstrap/ng2-bootstrap';
+import { PaginationModule } from 'ng2-bootstrap';
+import { TooltipModule } from 'ng2-bootstrap';
+import { TabsModule } from 'ng2-bootstrap';
 
 import { Ng2TableModule } from '../components/ng-table-module';
 
@@ -24,6 +25,7 @@ import { DemoComponent } from './demo.component';
     FormsModule,
     Ng2TableModule,
     PaginationModule,
+    TooltipModule,
     TabsModule,
     CommonModule
   ],

--- a/ng2-table.ts
+++ b/ng2-table.ts
@@ -3,6 +3,7 @@ import { NgTableComponent } from './components/table/ng-table.component';
 import { NgTableFilteringDirective } from './components/table/ng-table-filtering.directive';
 import { NgTablePagingDirective } from './components/table/ng-table-paging.directive';
 import { NgTableSortingDirective } from './components/table/ng-table-sorting.directive';
+import { TooltipDirective } from 'ng2-bootstrap';
 
 export * from './components/table/ng-table.component';
 
@@ -17,7 +18,8 @@ export default {
     NgTableComponent,
     NgTableFilteringDirective,
     NgTableSortingDirective,
-    NgTablePagingDirective
+    NgTablePagingDirective,
+    TooltipDirective
   ]
 };
 


### PR DESCRIPTION
I made a fork and implemented so it's possible to add more than one action button at the last column. It's a simple implementation, that following the same pattern from the ng2-table team.

Basically, I created a object that represents the action buttons that should be displayed at the table. The action may be identified by it's type.
```javascript
export const TableActions:Array<any> = [
 {
   'title': '',
   'type': 'edit',
   'tooltip': 'Edit',
   'classBtn': '',
   'classIcon': 'fa fa-pencil',
 },
 {
   'title': '',
   'type': 'delete',
   'tooltip': 'Delete',
   'classBtn': '',
   'classIcon': 'fa fa-trash',
 }
];
```