### PR TITLE
Added css class to column cells

### DIFF
--- a/components/table/ng-table.component.ts
+++ b/components/table/ng-table.component.ts
@@ -27,7 +27,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
         </td>
       </tr>
         <tr *ngFor="let row of rows">
-          <td (click)="cellClick(row, column.name)" *ngFor="let column of columns" [innerHtml]="sanitize(getData(row, column.name))"></td>
+          <td (click)="cellClick(row, column.name)" *ngFor="let column of columns" [innerHtml]="sanitize(getData(row, column.name))" ngClass="{{column.className || ''}}></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
At this moment we aren't able to style the cells of a column without doing any dirty selector with css. 
But  with this change we'll be able to edit the styles of a cell if we use the same that it is given to a column header. For example let's say that we have the following column in the table: 

```
const columns = [
      { name: 'name', className: 'custom-column' },
    ];
```

By doing this we could style the cells with css like this:
```

td.custom-column {
  ....
} 
```